### PR TITLE
A single awk call can do all of it

### DIFF
--- a/scripts/attached_clients.sh
+++ b/scripts/attached_clients.sh
@@ -12,7 +12,7 @@ source $current_dir/utils.sh
 
 count_clients() {
   pane=$(tmux list-panes -F "#{session_name}" | head -n 1)
-  tmux list-clients -t $pane | wc -l | tr -d ' '
+  tmux list-clients -t $pane | awk 'END{print NR}'
 }
 
 main() {

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -24,10 +24,10 @@ linux_acpi() {
   else
     case "$arg" in
       status)
-        acpi | cut -d: -f2- | cut -d, -f1 | tr -d ' '
+        acpi | awk -F'[:,]' '{gsub(/ /,"",$2); print $2}'
         ;;
       percent)
-        acpi | cut -d: -f2- | cut -d, -f2 | tr -d '% '
+        acpi | awk -F'[:,]' '{gsub(/[% ]/,"",$3); print $3}'
         ;;
       *)
         ;;
@@ -49,7 +49,7 @@ battery_percent()
       ;;
 
     FreeBSD)
-      echo $(apm | sed '8,11d' | grep life | awk '{print $4}')
+      echo $(apm | awk 'NR>=8&&NR<=11{next} /life/{print $4}')
       ;;
 
     CYGWIN*|MINGW32*|MSYS*|MINGW*)
@@ -70,11 +70,11 @@ battery_status()
       ;;
 
     Darwin)
-      status=$(pmset -g batt | sed -n 2p | cut -d ';' -f 2 | tr -d " ")
+      status=$(pmset -g batt | awk -F';' 'NR==2 {gsub(/ /,"",$2); print $2}')
       ;;
 
     FreeBSD)
-      status=$(apm | sed '8,11d' | grep Status | awk '{printf $3}')
+      status=$(apm | awk 'NR>=8&&NR<=11{next} /Status/{printf $3}')
       ;;
 
     CYGWIN*|MINGW32*|MSYS*|MINGW*)

--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -9,7 +9,7 @@ get_percent()
 {
   case $(uname -s) in
     Linux)
-      percent=$(LC_NUMERIC=en_US.UTF-8 top -bn2 -d 0.01 | grep "Cpu(s)" | tail -1 | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
+      percent=$(LC_NUMERIC=en_US.UTF-8 top -bn2 -d 0.01 | awk -F, '/Cpu\(s\)/{for(i=1;i<=NF;i++) if($i~/id/){idle=$i}} END{gsub(/[^0-9.]/,"",idle); printf "%.1f%%\n", 100-idle}')
       normalize_percent_len $percent
       ;;
 
@@ -38,7 +38,7 @@ get_percent()
 get_load() {
   case $(uname -s) in
   Linux | Darwin | OpenBSD)
-    loadavg=$(uptime | awk -F'[a-z]:' '{ print $2}' | sed 's/,//g')
+    loadavg=$(uptime | awk -F'[a-z]:' '{gsub(/,/,"",$2); print $2}')
     echo $loadavg
     ;;
 

--- a/scripts/fossil.sh
+++ b/scripts/fossil.sh
@@ -118,8 +118,8 @@ getRemoteInfo()
 
     if [ -n "$remote" ]; then
         out="...$remote"
-        ahead=$(echo "$base" | grep -E -o 'ahead[ [:digit:]]+' | cut -d" " -f2)
-        behind=$(echo "$base" | grep -E -o 'behind[ [:digit:]]+' | cut -d" " -f2)
+        ahead=$(echo "$base" | awk '{for(i=1;i<=NF;i++) if($i~/ahead/){v=$(i+1); gsub(/[^0-9]/,"",v); print v}}')
+        behind=$(echo "$base" | awk '{for(i=1;i<=NF;i++) if($i~/behind/){v=$(i+1); gsub(/[^0-9]/,"",v); print v}}')
 
         [ -n "$ahead" ] && out+=" +$ahead"
         [ -n "$behind" ] && out+=" -$behind"

--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -119,8 +119,8 @@ getRemoteInfo()
 
     if [ -n "$remote" ]; then
         out="...$remote"
-        ahead=$(echo "$base" | grep -E -o 'ahead[ [:digit:]]+' | cut -d" " -f2)
-        behind=$(echo "$base" | grep -E -o 'behind[ [:digit:]]+' | cut -d" " -f2)
+        ahead=$(echo "$base" | awk '{for(i=1;i<=NF;i++) if($i~/ahead/){v=$(i+1); gsub(/[^0-9]/,"",v); print v}}')
+        behind=$(echo "$base" | awk '{for(i=1;i<=NF;i++) if($i~/behind/){v=$(i+1); gsub(/[^0-9]/,"",v); print v}}')
 
         [ -n "$ahead" ] && out+=" +$ahead"
         [ -n "$behind" ] && out+=" -$behind"

--- a/scripts/gpu_power.sh
+++ b/scripts/gpu_power.sh
@@ -9,7 +9,7 @@ get_platform()
 {
   case $(uname -s) in
     Linux)
-      gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
+      gpu=$(lspci -v | awk '/VGA/{print $5; exit}')
       echo $gpu
       ;;
 

--- a/scripts/gpu_ram_info.sh
+++ b/scripts/gpu_ram_info.sh
@@ -9,7 +9,7 @@ get_platform()
 {
   case $(uname -s) in
     Linux)
-      gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
+      gpu=$(lspci -v | awk '/VGA/{print $5; exit}')
       echo $gpu
       ;;
 

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -9,7 +9,7 @@ get_platform()
 {
   case $(uname -s) in
     Linux)
-      gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
+      gpu=$(lspci -v | awk '/VGA/{print $5; exit}')
       echo $gpu
       ;;
 

--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -18,8 +18,8 @@ get_ssid()
       ;;
 
     Darwin)
-      if networksetup -getairportnetwork en0 | cut -d ':' -f 2 | sed 's/^[[:blank:]]*//g' &> /dev/null; then
-        echo "$(networksetup -getairportnetwork en0 | cut -d ':' -f 2)" | sed 's/^[[:blank:]]*//g'
+      if networksetup -getairportnetwork en0 | awk -F: '{gsub(/^[[:blank:]]*/,"",$2); print $2}' &> /dev/null; then
+        networksetup -getairportnetwork en0 | awk -F: '{gsub(/^[[:blank:]]*/,"",$2); print $2}'
       else
         echo 'Ethernet'
       fi

--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -48,7 +48,7 @@ interface_bytes() {
     ;;
   Darwin)
     # column 7 is Ibytes (in bytes, rx, download) and column 10 is Obytes (out bytes, tx, upload)
-    netstat -nbI "$1" | tail -n1 | awk '{print $10 " " $7}'
+    netstat -nbI "$1" | awk 'END{print $10 " " $7}'
     ;;
   esac
 }

--- a/scripts/network_ping.sh
+++ b/scripts/network_ping.sh
@@ -14,7 +14,7 @@ ping_function() {
   Linux | Darwin)
     # storing the hostname/IP in the variable PINGSERVER, default is 1.1.1.1 (Cloudflare)
     pingserver=$(get_tmux_option "@monokai-ping-server" "1.1.1.1")
-    pingtime=$(ping -c 1 "$pingserver" | tail -1 | awk '{print $4}' | cut -d '/' -f 2 | cut -c1-2 | sed 's/\.$//')
+    pingtime=$(ping -c 1 "$pingserver" | awk '/^rtt/ {split($4, a, "/"); printf("%d", a[2])}')
     echo "$pingtime ms"
     ;;
 

--- a/scripts/network_ping.sh
+++ b/scripts/network_ping.sh
@@ -14,7 +14,7 @@ ping_function() {
   Linux | Darwin)
     # storing the hostname/IP in the variable PINGSERVER, default is 1.1.1.1 (Cloudflare)
     pingserver=$(get_tmux_option "@monokai-ping-server" "1.1.1.1")
-    pingtime=$(ping -c 1 "$pingserver" | awk '/^rtt/ {split($4, a, "/"); printf("%d", a[2])}')
+    pingtime=$(ping -c 1 "$pingserver" | awk '/^(rtt|round-trip)/ {split($4, a, "/"); printf("%d", a[2])}')
     echo "$pingtime ms"
     ;;
 

--- a/scripts/ssh_session.sh
+++ b/scripts/ssh_session.sh
@@ -67,8 +67,8 @@ get_remote_info() {
   local port=$(parse_ssh_port "$cmd")
 
   local cmd=$(echo $cmd|sed 's/\-p\s*'"$port"'//g')
-  local user=$(echo $cmd | awk '{print $NF}'|cut -f1 -d@)
-  local host=$(echo $cmd | awk '{print $NF}'|cut -f2 -d@)
+  local user=$(echo $cmd | awk '{n=split($NF,a,"@"); print a[1]}')
+  local host=$(echo $cmd | awk '{n=split($NF,a,"@"); print (n>1 ? a[2] : a[1])}')
 
   if [ $user == $host ]; then
     local user=$(get_ssh_user $host)

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -36,8 +36,8 @@ display_weather()
   fi
   weather_information=$(fetch_weather_information $display_weather)
 
-  weather_condition=$(echo $weather_information | rev | cut -d ' ' -f2- | rev) # Sunny, Snow, etc
-  temperature=$(echo $weather_information | rev | cut -d ' ' -f 1 | rev) # +31°C, -3°F, etc
+  weather_condition=$(echo $weather_information | awk '{$NF=""; sub(/[[:space:]]+$/,""); print}') # Sunny, Snow, etc
+  temperature=$(echo $weather_information | awk '{print $NF}') # +31°C, -3°F, etc
   unicode=$(forecast_unicode $weather_condition)
 
   echo "$unicode${temperature/+/}" # remove the plus sign to the temperature


### PR DESCRIPTION
Hey, it is a small thing but sharing because I found myself wanting to reduce the number of subprocess spawns. Feel free to ignore and close :) 

```
❯ pingserver=1.1.1.1

❯ ping -c 1 "$pingserver" | awk '/^rtt/ {split($4, a, "/"); printf("%d", a[2])}'
10

❯ ping -c 1 "$pingserver" | tail -1 | awk '{print $4}' | cut -d '/' -f 2 | cut -c1-2 | sed 's/\.$//'
10
```